### PR TITLE
recaptcha timeout fix

### DIFF
--- a/django/captcha-notimeout/templates/captcha/includes/js_v3.html
+++ b/django/captcha-notimeout/templates/captcha/includes/js_v3.html
@@ -1,0 +1,17 @@
+<script src="https://{{ recaptcha_domain }}/recaptcha/api.js?render={{ public_key }}{% if api_params %}&{{ api_params }}{% endif %}"></script>
+<script type="text/javascript">
+
+    function updateCaptcha() {
+      grecaptcha.execute('{{ public_key }}', {action: 'form'})
+        .then(function(token) {
+            console.log("reCAPTCHA validated for 'data-widget-uuid=\"{{ widget_uuid }}\"'. Setting input value...")
+            var element = document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]');
+            element.value = token;
+        });
+    }
+
+    grecaptcha.ready(function() {
+      updateCaptcha();
+      setInterval(updateCaptcha, 110000)
+    });
+</script>

--- a/django/core/settings.py
+++ b/django/core/settings.py
@@ -18,7 +18,9 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.humanize',
     # 3rd Party
-    'captcha-notimeout',  # This is custom app to override "captcha" to prevent 2 minute timeouts
+    # captcha-notimeout is a custom app to override "captcha" to prevent 2 minute timeouts
+    # See: https://github.com/praekelt/django-recaptcha/issues/183
+    'captcha-notimeout',
     'captcha',
     'rest_framework',
     # Custom

--- a/django/core/settings.py
+++ b/django/core/settings.py
@@ -18,6 +18,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.humanize',
     # 3rd Party
+    'captcha-notimeout',  # This is custom app to override "captcha" to prevent 2 minute timeouts
     'captcha',
     'rest_framework',
     # Custom


### PR DESCRIPTION
Google reCAPTCHA will load a token on page load, which has to be verified within 2 minutes. Meaning when users take more than 2 minutes to submit the form (which is common) they will get a  500 error.

I use a django recaptcha for managing the google recaptcha, meaning I had to override it with a custom app to apply a fix, as suggested here: https://github.com/praekelt/django-recaptcha/issues/183 

This will reload the token every 110 seconds, meaning it will never hit the 2 minute timeout.