### PR TITLE
sending to multiple email addresses

### DIFF
--- a/django/researchdata/models.py
+++ b/django/researchdata/models.py
@@ -86,7 +86,7 @@ class Answer(models.Model):
                 send_mail('CLiC Calendar: New Answer',
                           'There has been a new answer submitted to CLiC Calendar.',
                           settings.DEFAULT_FROM_EMAIL,
-                          [settings.NOTIFICATION_EMAIL],
+                          settings.NOTIFICATION_EMAIL,
                           fail_silently=False)
             except Exception:
                 logger.exception("Failed to send email")


### PR DESCRIPTION
Currently the code in the model is written so that only one email recipient can be stated in the local settings.

This MR removes the list in the model, so that it can be set in the local settings file and therefore multiple recipients stated there.

As well as the update in this MR, @edmondac will need to change local_settings.py, chaning:

`NOTIFICATION_EMAIL = 'm.j.allaway@bham.ac.uk'`

to

`NOTIFICATION_EMAIL = ['v.wiegand@bham.ac.uk', 'm.a.mahlberg@bham.ac.uk']`